### PR TITLE
Fix batch processing for FetchedTranscriptSnippet objects (youtube-transcript-api >= 1.0)

### DIFF
--- a/batch_processing_yt.py
+++ b/batch_processing_yt.py
@@ -35,7 +35,10 @@ def get_video_info(video_id: str) -> dict:
 
 def process_transcript(transcript: List[dict]) -> List[str]:
     """Processes the transcript into paragraphs."""
-    full_text = ' '.join([fragment['text'] for fragment in transcript])
+    full_text = ' '.join(
+        getattr(fragment, "text", fragment.get("text", "") if isinstance(fragment, dict) else "")
+        for fragment in transcript
+    )
     full_text = re.sub(r'\[?[0-9]+:[0-9]+\]?', '', full_text)
     sentences = re.split(r'(?<=[.!?]) +', full_text)
 


### PR DESCRIPTION
## Problem

Running the batch CLI on `youtube-transcript-api >= 1.0` fails:

```
❌ An unexpected error occurred for video <id>: 'FetchedTranscriptSnippet' object is not subscriptable
```

In v1.0+, `transcript.fetch()` returns `FetchedTranscriptSnippet` objects rather than plain dicts. `process_transcript` in `batch_processing_yt.py` still indexes them with `fragment['text']`, which raises `TypeError`.

## Fix

Use the same accessor already adopted in `youtube_cli.py` (commit 84b5fbc, "Accepts list[dict] or FetchedTranscriptSnippet objects") — read `.text` via `getattr` with a dict `.get` fallback. This keeps both the old dict API and the new object API working.

```python
getattr(fragment, "text", fragment.get("text", "") if isinstance(fragment, dict) else "")
```

It looks like that earlier fix updated the interactive CLI but the batch script was missed; this completes it.

## Testing

Ran `python batch_processing_yt.py "<captioned video URL>" -f md` on `youtube-transcript-api 1.2.4` — previously errored, now writes the Markdown transcript successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transcript processing to handle different data formats more robustly, reducing potential processing failures and improving reliability when working with transcripts that may have varying data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->